### PR TITLE
problema de paginação resolvido com sucesso! 'ex_modulo_16'

### DIFF
--- a/bookstore_python/settings.py
+++ b/bookstore_python/settings.py
@@ -136,11 +136,11 @@ INTERNAL_TIPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 5,
+    'PAGE_SIZE': 10,
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.TokenAuthentication'
+        'rest_framework.authentication.TokenAuthentication',
     ]
 
 }

--- a/product/viewsets/product_viewset.py
+++ b/product/viewsets/product_viewset.py
@@ -1,12 +1,17 @@
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.pagination import PageNumberPagination
 
 from product.models import Product
 from product.serializers import ProductSerializer
 
+class ProductPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 1000
 
 class ProductViewSet(ModelViewSet):
-    
+    pagination_class = ProductPagination
     serializer_class = ProductSerializer
 
     def get_queryset(self):
@@ -14,5 +19,10 @@ class ProductViewSet(ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)  # Paginate the queryset
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        
         serializer = self.get_serializer(queryset, many=True)
         return Response({"results": serializer.data})


### PR DESCRIPTION
 Django REST Framework provides built-in pagination classes, but you need to explicitly enable pagination in your view.

To enable pagination, you need to make a few modifications to your ProductViewSet. 

*ProductPagination is a custom pagination class where you can specify the page_size, page_size_query_param, and max_page_size.
*pagination_class = ProductPagination enables pagination for your view.
*In the list method, it checks if pagination is requested (paginate_queryset method). If so, it paginates the queryset and returns a *paginated response. Otherwise, it returns the entire queryset without pagination.
![Screenshot from 2024-03-07 20-25-48](https://github.com/carlospaiva88/bookstore_python/assets/99406137/6981364d-002f-43f1-9986-b77c702bb924)
